### PR TITLE
Restructured HTTP Integration with authentication and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# IGNORE .TXT, .BIN, .CSV OUTPUTS WHEN COMMITTING
+*.bin
+*.csv
+*.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/HttpContent.py
+++ b/HttpContent.py
@@ -3,89 +3,106 @@ import json
 import ast
 
 
-
+"""
+A Class for handling all the HTTP requests to the Codec Analyzer Database.
+It works by gathering the input in the form of a list and transforming it into a Python dict 
+so that it can then be parsed as JSON and sent.
+"""
 class HttpContent:
-    """
-    A Class for handling all the HTTP requests to the Codec Analyzer Database.
-
-    It works by gathering the input in the form of a list and transforming it into a Python dict 
-    so that it can then be parsed as JSON and sent.
-    """
-
-
+    
     def __init__(self, base_url: str) -> None:
         self.base_url = base_url
 
 
-    def GET(self) -> list:
+    """
+    Checks if there is an entry with the given parameters as columns in the Database
+    
+    @param str unique_config: unique configuration string to represent the codification process
+    @param str commit_hash: the github commit hash for the codec
+    @returns bool
+    """
+    def hasEntry(
+        self, commitHash, uniqueVideoAttrs, uniqueConfigAttrs
+    ) -> dict:
+        url = f"{self.base_url}/encoding-results/has-entry/{uniqueVideoAttrs}/{uniqueConfigAttrs}/{commitHash}"
+        response = requests.request("GET", url, headers={}, data={})
+        return json.loads(response.content or 'null')
+
+    # NOTE to self:
+    # should the Codec class really be the one containing the Video and EncodingResult? 
+    # would it not be better for them to be separate? Something to think about.
+
+    """
+    Saves the EncodingResult on the database, 
+    mapping the entities with their respective Python classes in a 1:1 relationship.
+
+    @params codec: Codec
+    @params results: EncodingResult
+    @returns requesst.Response 
+    """
+    def POST_encoding_result(self, codec, results) -> requests.Response: 
+        video = codec.get_video()
+        encoding_config = codec.get_encoding_config()
+
+        payload = json.dumps({
+            "codec": {
+                "name": codec.get_codec(),
+                "commitHash": codec.get_commit_hash(),
+                "codecAttrs": codec.get_base_attrs(),
+            },
+            "video": {
+                "name": video.get_name(),
+                "resolution": video.get_resolution(),
+                "fps": video.get_fps(),
+                "nFrames": video.get_framesnumber(),
+                "format": video.get_format(),
+                "uniqueAttrs": video.get_unique_attrs() 
+            },
+            "encodingConfig": {
+                "uniqueAttrs": encoding_config.get_unique_attrs(),
+                "qp": encoding_config.qp,
+                "nFrames": encoding_config.nFrames,
+                "nThreads": encoding_config.nThreads,
+                "codecAttrs": encoding_config.codecSetAttrs,
+                "preset": encoding_config.preset
+            },
+            "ypsnr": results["ypsnr"],
+            "upsnr": results["upsnr"],
+            "vpsnr": results["vpsnr"],
+            "yuvpsnr": results["yuvpsnr"],
+            "bitrate": results["bitrate"],
+            "time": results["time"],
+            "energyConsumption": results["energyConsumption"] 
+        })
+
+        headers = {'Content-Type': 'application/json'}
+        response = requests.request("POST", f"{self.base_url}/encoding-results", headers=headers, data=payload)
+        return response
+
+
+    """
+    Gets all the saved EncodingResults from the Database and returns them in the form of of a list
+
+    @returns list of all available EncodingResults
+    """
+    def GET_all_encoding_results(self) -> list:
         response = requests.get(self.base_url)
         return ast.literal_eval(response.text)
-
-
-    def POST(self, info: dict) -> requests.Response:
-        payload = json.dumps({
-            "codec": info["codec"],
-            "commitHash": info["commitHash"],
-            "uniqueConfig": info["uniqueConfig"],
-            "video": info["video"],
-            "resolution": info["resolution"],
-            "fps": info["fps"],
-            "nFrames": info["nFrames"],
-            "qp": info["qp"],
-            "yPSNR": info["ypsnr"],
-            "uPSNR": info["upsnr"],
-            "vPSNR": info["vpsnr"],
-            "yuvPSNR": info["yuvpsnr"],
-            "bitrate": info["bitrate"],
-            "time": info["time"]
-        })
-        headers = {'Content-Type': 'application/json'}
-        response = requests.request("POST", self.base_url, headers=headers, data=payload)
-        return response
     
 
-    def PUT(self, id: str, info: dict) -> requests.Response:
-        payload = json.dumps({
-            "codec": info["codec"],
-            "commitHash": info["commitHash"],
-            "uniqueConfig": info["uniqueConfig"],
-            "video": info["video"],
-            "resolution": info["resolution"],
-            "fps": info["fps"],
-            "nFrames": info["nFrames"],
-            "qp": info["qp"],
-            "yPSNR": info["ypsnr"],
-            "uPSNR": info["upsnr"],
-            "vPSNR": info["vpsnr"],
-            "yuvPSNR": info["yuvpsnr"],
-            "bitrate": info["bitrate"],
-            "time": info["time"]
-        })
-        url = self.base_url + f"/{id}"
-        headers = {'Content-Type': 'application/json'}
-        response = requests.request("PUT", url, headers=headers, data=payload)
-        return response
-    
+    """
+    Deletes an EncodingResult from the Database. 
+    This should only be done in case of a wrong configuration, or something of the sort,
+    so that the data goes unaldutered. 
 
-    def DELETE(self, id: str) -> requests.Response:
+    @param id: the specific EncoidngResult ID, generated by the server
+    @returns requests.Response
+    """
+    def DELETE_encoding_result(self, id: str) -> requests.Response:
         url = self.base_url + f"/{id}"
         headers = {'Content-Type': 'application/json'}
         response = requests.request("DELETE", url, headers=headers)
         return response
-
-
-    def hasEntry(self, unique_config, commit_hash) -> bool:
-        """
-        Checks if there is an entry with the given parameters as columns in the Database
-
-        @param str unique_config: unique configuration string to represent the codification process
-        @param str commit_hash: the github commit hash for the codec
-        @returns bool
-        """
-
-        url = f"{self.base_url}/statsUnique?commitHash={commit_hash}&uniqueConfig={unique_config}"
-        response = requests.request("GET", url, headers={}, data={})
-        return response.content
     
 
     """

--- a/Logger.py
+++ b/Logger.py
@@ -40,9 +40,9 @@ class Logger(object, metaclass=SingletonType):
     def get_logger(self):
         return self._logger
 
-    def info(self, str):
-        self._logger.info(str)
+    def info(self, message):
+        self._logger.info(message)
     
-    def debug(self, str):
-        self._logger.debug(str)
+    def debug(self, message):
+        self._logger.debug(message)
 

--- a/Video.py
+++ b/Video.py
@@ -63,6 +63,13 @@ class Video():
     
     
     """GETTERS AND SETTERS"""
+    def get_unique_attrs(self) -> str:
+        """
+        This is mean to be an unique identifier for each video, used as a foreign key in the database.
+        It may look cryptic to a human, but the machine will understand it.
+        """
+        return f"f{self.__format}fps{self.__fps}n{self.__name}r{self.__resolution}f{self.__framesnumber}"
+
 
     def get_format(self):
         return self.__format

--- a/video_codecs/Codec.py
+++ b/video_codecs/Codec.py
@@ -18,7 +18,6 @@ class Codec(ABC):
             self._options_encoder = data['options_encoder']
             self._options_decoder = data['options_decoder']
 
-    # TODO: add hash dos codecs (erro se n tiver)
 
     """GETTERS"""
     def get_codec(self) -> str:
@@ -37,7 +36,27 @@ class Codec(ABC):
         return self._decoder_path
     
 
+    def get_qp(self) -> int:
+        return self._options_encoder["qp"] 
+
+    
+    def get_preset(self) -> str:
+        return self._options_encoder["preset"]
+    
+
+    def get_num_frames(self) -> int:
+        return self._options_encoder["frames"]
+
+
+    def get_video(self):
+        return self._video
+    
+
     """SETTERS"""
+    def set_qp(self, val) -> None:
+        self._options_encoder["qp"] = val
+
+
     def set_encoder_option(self, name, val) -> None:
         self._options_encoder[name] = val
    
@@ -49,18 +68,20 @@ class Codec(ABC):
     def set_commit_hash(self, commit_hash: str) -> None:
         self._commit_hash = commit_hash
 
+    
+    def set_num_frames(self, val) -> None:
+        self._options_encoder["frames"] = val
+    
+
+    def set_preset(self, val) -> None:
+        self._options_encoder["preset"] = val
+
+    
+    def set_video(self, video) -> None:
+        self._video = video
+
 
     """ABSTRACT METHODS"""
-    @abstractmethod
-    def set_qp(self, val):
-        pass
-    
-    
-    @abstractmethod
-    def set_num_frames(self, val):
-        pass
-
-
     @abstractmethod
     def encode(self):
         pass
@@ -82,7 +103,7 @@ class Codec(ABC):
 
 
     @abstractmethod
-    def get_encoding_config(self):
+    def get_unique_attrs(self):
         pass
 
 

--- a/video_codecs/EncodingConfig.py
+++ b/video_codecs/EncodingConfig.py
@@ -6,8 +6,16 @@ class EncodingConfig:
     qp: int
     nFrames: int
     fps: float
-    preset: str 
-    uniqueConfig: str 
+    preset: str  
     nThreads: int = 1
     codecSetAttrs: str = ""
+
+
+    def get_unique_attrs(self) -> str:
+        """
+        There probably is another way of doing this
+        leave it to future me to figure out 👍
+        """
+        return f"q{self.qp}f{self.nFrames}fps{self.fps}p{self.preset}\
+t{self.nThreads}a{self.codecSetAttrs.replace(' ', '')}"
     


### PR DESCRIPTION
Authentication is now functional through the `authenticate(creds: str)` method on `HttpContent.py`, that uses the "private" method `POST_auth(self, creds: dict)`. 

The software will make a request of type `POST` to the API's authentication endpoint (/auth/authenticate). If it succeeds, `HttpContent` sets the acquired token as an attribute and uses it in the headers of the other requests to validate the connection.

Also changed some minor things like adding getters and setters, changed names, added child methods to parent class for better generalization, etc.  